### PR TITLE
fix string encoding when using xcom / json

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -269,7 +269,12 @@ class DockerOperator(BaseOperator):
             # duplicated conditional logic because of expensive operation
             ret = None
             if self.do_xcom_push:
-                ret = self.cli.logs(container=self.container['Id']) if self.xcom_all else line.encode('utf-8')
+                if self.xcom_all:
+                    ret = self.cli.logs(container=self.container['Id'])
+                    if hasattr(ret, 'decode'):
+                        ret = ret.decode('utf-8')
+                else:
+                    ret = line.split('\n')[-1]
 
             if self.auto_remove:
                 self.cli.remove_container(self.container['Id'])


### PR DESCRIPTION
closes: #13535

fixes the xcom issue by decoding the byte array of the log file before submitting it to xcom